### PR TITLE
Added Support for API 19

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -51,6 +51,9 @@
         </config-file>
 
         <source-file src="src/android/SecureStorage.java" target-dir="src/com/crypho/plugins/" />
+        <source-file src="src/android/RSALegacy.java" target-dir="src/com/crypho/plugins/" />
+        <source-file src="src/android/RSAFactory.java" target-dir="src/com/crypho/plugins/" />
+        <source-file src="src/android/AbstractRSA.java" target-dir="src/com/crypho/plugins/" />
         <source-file src="src/android/RSA.java" target-dir="src/com/crypho/plugins/" />
         <source-file src="src/android/AES.java" target-dir="src/com/crypho/plugins/" />
         <source-file src="src/android/SharedPreferencesHandler.java" target-dir="src/com/crypho/plugins/" />

--- a/src/android/AES.java
+++ b/src/android/AES.java
@@ -13,7 +13,7 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.KeyGenerator;
 
 public class AES {
-    private static final String CIPHER_MODE = "CCM";
+    private static final String CIPHER_MODE = "GCM";
     private static final int KEY_SIZE = 256;
     private static final int VERSION = 1;
     private static final Cipher CIPHER = getCipher();

--- a/src/android/AbstractRSA.java
+++ b/src/android/AbstractRSA.java
@@ -1,0 +1,112 @@
+package com.crypho.plugins;
+
+import android.content.Context;
+import android.os.Build;
+import android.security.keystore.KeyProperties;
+
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.spec.AlgorithmParameterSpec;
+
+import javax.crypto.Cipher;
+
+public abstract class AbstractRSA {
+    protected static final String TAG = "SecureStorage";
+    static final Integer CERT_VALID_YEARS = 100;
+    static final String KEYSTORE_PROVIDER = "AndroidKeyStore";
+    private final Cipher CIPHER = getCipher();
+
+
+    abstract AlgorithmParameterSpec getInitParams(Context ctx, String alias, Integer userAuthenticationValidityDuration) throws Exception;
+
+    boolean encryptionKeysAvailable(String alias) {
+        return isEntryAvailable(alias);
+    }
+
+    String getRSAKey() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return KeyProperties.KEY_ALGORITHM_RSA;
+        }
+        return "RSA";
+    }
+
+    private Cipher getCipher() {
+        try {
+            return Cipher.getInstance("RSA/ECB/PKCS1Padding");
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private byte[] runCipher(int cipherMode, String alias, byte[] buf) throws Exception {
+        Key key = loadKey(cipherMode, alias);
+        assert CIPHER != null;
+        synchronized (CIPHER) {
+            CIPHER.init(cipherMode, key);
+            return CIPHER.doFinal(buf);
+        }
+    }
+
+    void createKeyPair(Context ctx, String alias, Integer userAuthenticationValidityDuration) throws Exception {
+        AlgorithmParameterSpec spec = getInitParams(ctx, alias, userAuthenticationValidityDuration);
+        KeyPairGenerator kpGenerator = KeyPairGenerator.getInstance(getRSAKey(), KEYSTORE_PROVIDER);
+        kpGenerator.initialize(spec);
+        kpGenerator.generateKeyPair();
+    }
+
+    public byte[] encrypt(byte[] buf, String alias) throws Exception {
+        return runCipher(Cipher.ENCRYPT_MODE, alias, buf);
+    }
+
+
+    public byte[] decrypt(byte[] buf, String alias) throws Exception {
+        return runCipher(Cipher.DECRYPT_MODE, alias, buf);
+    }
+
+    protected abstract boolean isEntryAvailable(String alias);
+
+    Key loadKey(int cipherMode, String alias) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER);
+        keyStore.load(null, null);
+
+        if (!keyStore.containsAlias(alias)) {
+            throw new Exception("KeyStore doesn't contain alias: " + alias);
+        }
+
+        Key key;
+        switch (cipherMode) {
+            case Cipher.ENCRYPT_MODE:
+                key = keyStore.getCertificate(alias).getPublicKey();
+                if (key == null) {
+                    throw new Exception("Failed to load the public key for " + alias);
+                }
+                break;
+            case Cipher.DECRYPT_MODE:
+                key = keyStore.getKey(alias, null);
+                if (key == null) {
+                    throw new Exception("Failed to load the private key for " + alias);
+                }
+                break;
+            default:
+                throw new Exception("Invalid cipher mode parameter");
+        }
+        return key;
+    }
+
+    boolean userAuthenticationRequired(String alias) {
+        try {
+            // Do a quick encrypt/decrypt test
+            byte[] encrypted = encrypt(alias.getBytes(), alias);
+            decrypt(encrypted, alias);
+            return false;
+        } catch (InvalidKeyException noAuthEx) {
+            return true;
+        } catch (Exception e) {
+            // Other
+            return false;
+        }
+    }
+}
+

--- a/src/android/AbstractRSA.java
+++ b/src/android/AbstractRSA.java
@@ -49,7 +49,7 @@ public abstract class AbstractRSA {
         }
     }
 
-    void createKeyPair(Context ctx, String alias, Integer userAuthenticationValidityDuration) throws Exception {
+    public void createKeyPair(Context ctx, String alias, Integer userAuthenticationValidityDuration) throws Exception {
         AlgorithmParameterSpec spec = getInitParams(ctx, alias, userAuthenticationValidityDuration);
         KeyPairGenerator kpGenerator = KeyPairGenerator.getInstance(getRSAKey(), KEYSTORE_PROVIDER);
         kpGenerator.initialize(spec);

--- a/src/android/RSA.java
+++ b/src/android/RSA.java
@@ -3,6 +3,8 @@ package com.crypho.plugins;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyInfo;
 import android.security.keystore.KeyProperties;
 import android.util.Log;
 
@@ -23,13 +25,9 @@ public class RSA extends AbstractRSA {
             if (privateKey == null) {
                 return false;
             }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                android.security.keystore.KeyInfo keyInfo;
-                KeyFactory factory = KeyFactory.getInstance(privateKey.getAlgorithm(), KEYSTORE_PROVIDER);
-                keyInfo = factory.getKeySpec(privateKey, android.security.keystore.KeyInfo.class);
-                return keyInfo.isInsideSecureHardware();
-            }
-            return false;
+            KeyFactory factory = KeyFactory.getInstance(privateKey.getAlgorithm(), KEYSTORE_PROVIDER);
+            KeyInfo keyInfo = factory.getKeySpec(privateKey, KeyInfo.class);
+            return keyInfo.isInsideSecureHardware();
         } catch (Exception e) {
             Log.i(TAG, "Checking encryption keys failed.", e);
             return false;
@@ -43,7 +41,7 @@ public class RSA extends AbstractRSA {
         notAfter.add(Calendar.YEAR, CERT_VALID_YEARS);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            return new android.security.keystore.KeyGenParameterSpec.Builder(alias, KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
+            return new KeyGenParameterSpec.Builder(alias, KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
                 .setCertificateNotBefore(Calendar.getInstance().getTime())
                 .setCertificateNotAfter(notAfter.getTime())
                 .setAlgorithmParameterSpec(new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4))

--- a/src/android/RSA.java
+++ b/src/android/RSA.java
@@ -7,6 +7,8 @@ import android.security.KeyPairGeneratorSpec;
 import android.security.keystore.KeyProperties;
 import android.util.Log;
 
+import javax.crypto.Cipher;
+import javax.security.auth.x500.X500Principal;
 import java.math.BigInteger;
 import java.security.Key;
 import java.security.KeyFactory;
@@ -15,9 +17,6 @@ import java.security.KeyStore;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.RSAKeyGenParameterSpec;
 import java.util.Calendar;
-
-import javax.crypto.Cipher;
-import javax.security.auth.x500.X500Principal;
 
 public class RSA {
     private static final String KEYSTORE_PROVIDER = "AndroidKeyStore";
@@ -37,14 +36,17 @@ public class RSA {
     public static void createKeyPair(Context ctx, String alias, Integer userAuthenticationValidityDuration) throws Exception {
         AlgorithmParameterSpec spec = IS_API_23_AVAILABLE ? getInitParams(alias, userAuthenticationValidityDuration) : getInitParamsLegacy(ctx, alias);
 
-        KeyPairGenerator kpGenerator = KeyPairGenerator.getInstance(getRSAProperty(), KEYSTORE_PROVIDER);
+        KeyPairGenerator kpGenerator = KeyPairGenerator.getInstance(getRSAKey(), KEYSTORE_PROVIDER);
         kpGenerator.initialize(spec);
         kpGenerator.generateKeyPair();
     }
 
 
-    public static String getRSAProperty() {
-        return KeyProperties.KEY_ALGORITHM_RSA;
+    public static String getRSAKey() {
+        if (IS_API_23_AVAILABLE) {
+            return KeyProperties.KEY_ALGORITHM_RSA;
+        }
+        return "RSA";
     }
 
     /**
@@ -196,7 +198,7 @@ public class RSA {
             .setEndDate(notAfter.getTime())
             .setEncryptionRequired()
             .setKeySize(2048)
-            .setKeyType(getRSAProperty())
+            .setKeyType(getRSAKey())
             .build();
     }
 }

--- a/src/android/RSAFactory.java
+++ b/src/android/RSAFactory.java
@@ -1,0 +1,12 @@
+package com.crypho.plugins;
+
+import android.os.Build;
+
+public class RSAFactory {
+    public static AbstractRSA getRSA() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return new RSALegacy();
+        }
+        return new RSA();
+    }
+}

--- a/src/android/RSALegacy.java
+++ b/src/android/RSALegacy.java
@@ -1,0 +1,43 @@
+package com.crypho.plugins;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.security.KeyPairGeneratorSpec;
+
+import java.math.BigInteger;
+import java.security.spec.AlgorithmParameterSpec;
+import java.util.Calendar;
+
+import javax.crypto.Cipher;
+import javax.security.auth.x500.X500Principal;
+
+public class RSALegacy extends AbstractRSA {
+
+    @Override
+    public boolean isEntryAvailable(String alias) {
+        try {
+            return loadKey(Cipher.ENCRYPT_MODE, alias) != null;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    public AlgorithmParameterSpec getInitParams(Context ctx, String alias, Integer userAuthenticationValidityDuration) throws Exception {
+        Calendar notAfter = Calendar.getInstance();
+        notAfter.add(Calendar.YEAR, CERT_VALID_YEARS);
+
+        return new KeyPairGeneratorSpec.Builder(ctx)
+            .setAlias(alias)
+            .setSubject(new X500Principal(String.format("CN=%s, OU=%s", alias, ctx.getPackageName())))
+            .setSerialNumber(BigInteger.ONE)
+            .setStartDate(Calendar.getInstance().getTime())
+            .setEndDate(notAfter.getTime())
+            .setEncryptionRequired()
+            .setKeySize(2048)
+            .setKeyType(getRSAKey())
+            .build();
+    }
+}

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -25,7 +25,7 @@ public class SecureStorage extends CordovaPlugin {
     private static final boolean SUPPORTED = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
     private static final Integer DEFAULT_AUTHENTICATION_VALIDITY_TIME = 60 * 60 * 24; // Fallback to 24h. Workaround to avoid asking for credentials too "often"
 
-    private static final String MSG_NOT_SUPPORTED = "API 19 (Android 4.4 Lollipop) is required. This device is running API " + Build.VERSION.SDK_INT;
+    private static final String MSG_NOT_SUPPORTED = "API 19 (Android 4.4 KitKat) is required. This device is running API " + Build.VERSION.SDK_INT;
     private static final String MSG_DEVICE_NOT_SECURE = "Device is not secure";
     private static final String MSG_KEYS_FAILED = "Generate RSA Encryption Keys failed. ";
 


### PR DESCRIPTION
In the project I'm currently working on we need to keep compatibility from a minimum of Android 19.

I restored support making a RSA factory, to use legacy API only if needed.

I also had to change AES Cypher to GCM instead of CCM because I was having problems in Android 4.4.4 (Encryption was failing due to Cypher length).