### PR TITLE
Handle nullable Confirm Credentials Intent

### DIFF
--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -237,7 +237,12 @@ public class SecureStorage extends CordovaPlugin {
             public void run() {
                 KeyguardManager keyguardManager = (KeyguardManager) (getContext().getSystemService(Context.KEYGUARD_SERVICE));
                 Intent intent = keyguardManager.createConfirmDeviceCredentialIntent(title, description);
-                startActivity(intent);
+                if (intent != null) {
+                    startActivity(intent);
+                } else {
+                    Log.e(TAG, "Error creating Confirm Credentials Intent");
+                    unlockCredentialsContext.error("Cant't unlock credentials, error creating Confirm Credentials Intent");
+                }
             }
         });
     }


### PR DESCRIPTION
When user authentication is required and we have to confirm authentication via device credentials, the result of KeyguardManager.createConfirmDeviceCredentialIntent() can be null.