### PR TITLE
Added KeyPermanentlyInvalidatedException handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+.idea

--- a/src/android/AbstractRSA.java
+++ b/src/android/AbstractRSA.java
@@ -111,10 +111,8 @@ public abstract class AbstractRSA {
             byte[] encrypted = encrypt(alias.getBytes(), alias);
             decrypt(encrypted, alias);
             return false;
-        } catch (KeyPermanentlyInvalidatedException keyInvalidEx) {
-            deleteKey(alias);
-            return true;
         } catch (InvalidKeyException noAuthEx) {
+            deleteKey(alias);
             return true;
         } catch (Exception e) {
             // Other

--- a/src/android/AbstractRSA.java
+++ b/src/android/AbstractRSA.java
@@ -111,8 +111,10 @@ public abstract class AbstractRSA {
             byte[] encrypted = encrypt(alias.getBytes(), alias);
             decrypt(encrypted, alias);
             return false;
-        } catch (InvalidKeyException noAuthEx) {
+        } catch (KeyPermanentlyInvalidatedException keyInvalidEx) {
             deleteKey(alias);
+            return true;
+        } catch (InvalidKeyException noAuthEx) {
             return true;
         } catch (Exception e) {
             // Other

--- a/src/android/AbstractRSA.java
+++ b/src/android/AbstractRSA.java
@@ -3,6 +3,7 @@ package com.crypho.plugins;
 import android.content.Context;
 import android.os.Build;
 import android.security.keystore.KeyProperties;
+import android.util.Log;
 
 import java.security.InvalidKeyException;
 import java.security.Key;

--- a/src/android/AbstractRSA.java
+++ b/src/android/AbstractRSA.java
@@ -95,6 +95,16 @@ public abstract class AbstractRSA {
         return key;
     }
 
+    private void deleteKey(String alias) {
+      try {
+          KeyStore keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER);
+          keyStore.load(null, null);
+          keyStore.deleteEntry(alias);
+      } catch (Exception e) {
+          Log.e(TAG, "Exception deleting key", e);
+      }
+    }
+
     boolean userAuthenticationRequired(String alias) {
         try {
             // Do a quick encrypt/decrypt test
@@ -102,6 +112,7 @@ public abstract class AbstractRSA {
             decrypt(encrypted, alias);
             return false;
         } catch (InvalidKeyException noAuthEx) {
+            deleteKey(alias);
             return true;
         } catch (Exception e) {
             // Other


### PR DESCRIPTION
Customers were complaining that device would infinitely ask device password/PIN if they changed it.

I found out that initializing secure storage was bringing to the reuse of the same key, which was permanently invalidated from android system.

I created a method to delete the key if there is a KeyPermanentlyInvalidatedException, therefore the plugin will initialize a new key.