### PR TITLE
fix: further guard against NPEs

### DIFF
--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -53,12 +53,14 @@ public class SecureStorage extends CordovaPlugin {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 cordova.getThreadPool().execute(new Runnable() {
                     public void run() {
-                        String alias = service2alias(INIT_SERVICE);
-                        if (rsa.userAuthenticationRequired(alias)) {
-                            unlockCredentialsContext.error("User not authenticated");
+                        if (unlockCredentialsContext != null) {
+                            String alias = service2alias(INIT_SERVICE);
+                            if (rsa.userAuthenticationRequired(alias)) {
+                                unlockCredentialsContext.error("User not authenticated");
+                            }
+                            unlockCredentialsContext.success();
+                            unlockCredentialsContext = null;
                         }
-                        unlockCredentialsContext.success();
-                        unlockCredentialsContext = null;
                     }
                 });
             }


### PR DESCRIPTION
Because the success/error callbacks are executed in a new Runnable, the null safe check before the construction of the Runnable might not be sufficient.

Reference issue #24