### PR TITLE
Android guarantee key inside secure hw

### DIFF
--- a/src/android/AbstractRSA.java
+++ b/src/android/AbstractRSA.java
@@ -53,7 +53,16 @@ public abstract class AbstractRSA {
         AlgorithmParameterSpec spec = getInitParams(ctx, alias, userAuthenticationValidityDuration);
         KeyPairGenerator kpGenerator = KeyPairGenerator.getInstance(getRSAKey(), KEYSTORE_PROVIDER);
         kpGenerator.initialize(spec);
-        kpGenerator.generateKeyPair();
+        KeyPair keyPair = kpGenerator.generateKeyPair();
+        if (!isInsideSecureHardware(keyPair.getPrivate())) {
+            throw new Exception("Key is not stored in secure hardware");
+        }
+    }
+
+    boolean isInsideSecureHardware(Key privateKey) throws NoSuchProviderException, NoSuchAlgorithmException, InvalidKeySpecException {
+        KeyFactory factory = KeyFactory.getInstance(privateKey.getAlgorithm(), KEYSTORE_PROVIDER);
+        KeyInfo keyInfo = factory.getKeySpec(privateKey, KeyInfo.class);
+        return keyInfo.isInsideSecureHardware();
     }
 
     public byte[] encrypt(byte[] buf, String alias) throws Exception {

--- a/src/android/AbstractRSA.java
+++ b/src/android/AbstractRSA.java
@@ -2,13 +2,19 @@ package com.crypho.plugins;
 
 import android.content.Context;
 import android.os.Build;
+import android.security.keystore.KeyInfo;
 import android.security.keystore.KeyProperties;
 
 import java.security.InvalidKeyException;
 import java.security.Key;
+import java.security.KeyFactory;
+import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidKeySpecException;
 
 import javax.crypto.Cipher;
 


### PR DESCRIPTION
The isEmpty() check that was added after version 5.0.1 is causing issues when the Key becomes stale, eg. when a user changes their lockscreen. This check prevents a new key from being generated. Therefore we should get rid of it.

This should solve https://github.com/mibrito707/cordova-plugin-secure-storage-echo/issues/54
