### PR TITLE
Fix stale key issue

### DIFF
--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -274,11 +274,9 @@ public class SecureStorage extends CordovaPlugin {
                     try {
                         String alias = service2alias(INIT_SERVICE);
                         SharedPreferencesHandler storage = getStorage(INIT_SERVICE);
-                        if (storage.isEmpty()) {
-                            //Solves Issue #96. The RSA key may have been deleted by changing the lock type.
-                            getStorage(INIT_SERVICE).clear();
-                            rsa.createKeyPair(getContext(), alias, userAuthenticationValidityDuration);
-                        }
+                        //Solves Issue #96. The RSA key may have been deleted by changing the lock type.
+                        getStorage(INIT_SERVICE).clear();
+                        rsa.createKeyPair(getContext(), alias, userAuthenticationValidityDuration);
                         generateKeysContext.success();
                     } catch (Exception e) {
                         Log.e(TAG, MSG_KEYS_FAILED, e);


### PR DESCRIPTION
The isEmpty() check that was added after version 5.0.1 is causing issues when the Key becomes stale, eg. when a user changes their lockscreen. This check prevents a new key from being generated. Therefore we should get rid of it.

This should solve https://github.com/mibrito707/cordova-plugin-secure-storage-echo/issues/54
