### PR TITLE
Fix alias missing from keystore issue after user disabled his security

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -57,6 +57,7 @@
         <source-file src="src/android/RSA.java" target-dir="src/com/crypho/plugins/" />
         <source-file src="src/android/AES.java" target-dir="src/com/crypho/plugins/" />
         <source-file src="src/android/SharedPreferencesHandler.java" target-dir="src/com/crypho/plugins/" />
+        <source-file src="src/android/AliasMissingFromKeystoreException.java" target-dir="src/com/crypho/plugins/" />
     </platform>
 
     <platform name="browser">

--- a/src/android/AbstractRSA.java
+++ b/src/android/AbstractRSA.java
@@ -21,7 +21,7 @@ public abstract class AbstractRSA {
 
     abstract AlgorithmParameterSpec getInitParams(Context ctx, String alias, Integer userAuthenticationValidityDuration) throws Exception;
 
-    boolean encryptionKeysAvailable(String alias) {
+    boolean encryptionKeysAvailable(String alias) throws AliasMissingFromKeystoreException {
         return isEntryAvailable(alias);
     }
 
@@ -65,14 +65,14 @@ public abstract class AbstractRSA {
         return runCipher(Cipher.DECRYPT_MODE, alias, buf);
     }
 
-    protected abstract boolean isEntryAvailable(String alias);
+    protected abstract boolean isEntryAvailable(String alias) throws AliasMissingFromKeystoreException;
 
     Key loadKey(int cipherMode, String alias) throws Exception {
         KeyStore keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER);
         keyStore.load(null, null);
 
         if (!keyStore.containsAlias(alias)) {
-            throw new Exception("KeyStore doesn't contain alias: " + alias);
+            throw new AliasMissingFromKeystoreException("KeyStore doesn't contain alias: " + alias);
         }
 
         Key key;

--- a/src/android/AliasMissingFromKeystoreException.java
+++ b/src/android/AliasMissingFromKeystoreException.java
@@ -1,0 +1,7 @@
+package com.crypho.plugins;
+
+public class AliasMissingFromKeystoreException extends Exception {
+    AliasMissingFromKeystoreException(String message) {
+        super(message);
+    }
+}

--- a/src/android/RSA.java
+++ b/src/android/RSA.java
@@ -19,7 +19,7 @@ import javax.crypto.Cipher;
 public class RSA extends AbstractRSA {
 
     @TargetApi(Build.VERSION_CODES.M)
-    public boolean isEntryAvailable(String alias) {
+    public boolean isEntryAvailable(String alias) throws AliasMissingFromKeystoreException {
         try {
             Key privateKey = loadKey(Cipher.DECRYPT_MODE, alias);
             if (privateKey == null) {
@@ -28,6 +28,8 @@ public class RSA extends AbstractRSA {
             KeyFactory factory = KeyFactory.getInstance(privateKey.getAlgorithm(), KEYSTORE_PROVIDER);
             KeyInfo keyInfo = factory.getKeySpec(privateKey, KeyInfo.class);
             return keyInfo.isInsideSecureHardware();
+        } catch (AliasMissingFromKeystoreException e) {
+            throw e;
         } catch (Exception e) {
             Log.i(TAG, "Checking encryption keys failed.", e);
             return false;

--- a/src/android/RSALegacy.java
+++ b/src/android/RSALegacy.java
@@ -15,9 +15,11 @@ import javax.security.auth.x500.X500Principal;
 public class RSALegacy extends AbstractRSA {
 
     @Override
-    public boolean isEntryAvailable(String alias) {
+    public boolean isEntryAvailable(String alias) throws AliasMissingFromKeystoreException {
         try {
             return loadKey(Cipher.ENCRYPT_MODE, alias) != null;
+        } catch (AliasMissingFromKeystoreException e) {
+            throw e;
         } catch (Exception e) {
             return false;
         }


### PR DESCRIPTION
This is a more elaborate fix voor issue https://github.com/mibrito707/cordova-plugin-secure-storage-echo/issues/54. The isEmpty fix didn't work for us, since it resets the store on every app startup.

The original issue was that when the user disables his screen-lock and enabled it again the keystore is empty. The shared preferences storage is not empty however. 

Instead of always recreating the keypair, only recreate it when the alias is missing from the keystore, or the shared preferences are empty.